### PR TITLE
Fix: Integrate Flask-SocketIO with SwarmWebSocketNamespace

### DIFF
--- a/src/services/websocket_service.py
+++ b/src/services/websocket_service.py
@@ -267,8 +267,18 @@ class SwarmWebSocketNamespace(Namespace):
         
         logger.info(f"✅ Client connected: {user_id} (MCP: {mcp_status.get('status', 'unknown')})")
 
-    def on_send_message(self, data):
-        """Enhanced message handling with MCP filesystem support"""
+    def on_disconnect(self):
+        """Handle client disconnection"""
+        client_id = request.sid
+        if client_id in self.connected_clients:
+            user_id = self.connected_clients[client_id].get("user_id", "unknown")
+            del self.connected_clients[client_id]
+            logger.info(f"Client disconnected: {user_id} ({client_id})")
+        else:
+            logger.info(f"Client disconnected: {client_id} (already removed or not found)")
+
+    def on_user_message(self, data): # Renamed from on_send_message
+        """Enhanced message handling with MCP filesystem support, receives messages from users."""
         try:
             client_id = request.sid
             


### PR DESCRIPTION
## Summary
- Integrated Flask-SocketIO properly by using SwarmWebSocketNamespace from websocket_service.py
- Removed duplicate SwarmNamespace definition from main.py
- Fixed WebSocket event handlers to align with client-side implementation

## Changes Made
1. **main.py**:
   - Removed the local SwarmNamespace class definition
   - Now imports and uses SwarmWebSocketNamespace from websocket_service.py
   - Properly passes websocket_service instance to the namespace

2. **websocket_service.py**:
   - Added `on_disconnect` handler for proper client cleanup and logging
   - Renamed `on_send_message` to `on_user_message` to match client expectations
   - Maintains all existing functionality including MCP filesystem support

## Test plan
- [x] Dependencies installed successfully
- [x] Application starts without syntax errors
- [x] WebSocket namespace properly registered
- [ ] Manual testing of WebSocket connections
- [ ] Verify client can connect to /swarm namespace
- [ ] Test message sending between client and server

🤖 Generated with [Claude Code](https://claude.ai/code)